### PR TITLE
update: handle error and call onSelect with null when no choice is made

### DIFF
--- a/src/Action.tsx
+++ b/src/Action.tsx
@@ -8,25 +8,33 @@ interface SelectFileProps
   prompt?: string;
   type?: string;
   onSelect(filePath: string): unknown;
+  onError(): unknown;
 }
 
 export const SelectFile = ({
   onSelect,
+  onError,
   prompt = 'Please select a file',
   type,
   ...props
 }: SelectFileProps): JSX.Element => {
   const handleSelectFromFinder = useCallback(async () => {
-    const path = await runAppleScript(`
-      set chosenFile to choose file with prompt "${prompt}:"${
-      type != null ? `of type {"${type}"}` : ''
-    }
-      set raycastPath to POSIX path of (path to application "Raycast")
-      do shell script "open " & raycastPath
-      return POSIX path of chosenFile
-    `);
-    if (path) {
-      onSelect(path);
+    try {
+      const path = await runAppleScript(`
+        set chosenFile to choose file with prompt "${prompt}:"${
+        type != null ? `of type {"${type}"}` : ''
+      }
+        set raycastPath to POSIX path of (path to application "Raycast")
+        do shell script "open " & raycastPath
+        return POSIX path of chosenFile
+      `);
+      if (path) {
+        onSelect(path);
+      } else {
+        onError()
+      }
+    } catch(e) {
+      onError()
     }
   }, []);
 

--- a/src/Action.tsx
+++ b/src/Action.tsx
@@ -7,13 +7,11 @@ interface SelectFileProps
   extends Omit<ComponentProps<typeof Action>, 'onAction'> {
   prompt?: string;
   type?: string;
-  onSelect(filePath: string): unknown;
-  onError(): unknown;
+  onSelect(filePath: string|null): unknown;
 }
 
 export const SelectFile = ({
   onSelect,
-  onError,
   prompt = 'Please select a file',
   type,
   ...props
@@ -31,10 +29,10 @@ export const SelectFile = ({
       if (path) {
         onSelect(path);
       } else {
-        onError()
+        onSelect(null);
       }
     } catch(e) {
-      onError()
+      onSelect(null);
     }
   }, []);
 


### PR DESCRIPTION
fixes https://github.com/FezVrasta/raycast-toolkit/issues/3

- this adds `onError` callback in SelectFile
- wrapper file picking in `try catch` to make sure it doesn't break when file picker is closed without selecting any file

@FezVrasta please share your thoughts, thanks :)